### PR TITLE
Use github API to get releases not tags

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,9 +2,11 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/aquasecurity/trivy"
 TOOL_NAME="trivy"
 TOOL_TEST="trivy --version"
+OWNER="aquasecurity"
+REPO="$TOOL_NAME"
+GH_REPO="https://github.com/${OWNER}/${REPO}"
 
 fail() {
   echo -e "asdf-$TOOL_NAME: $*"
@@ -18,13 +20,15 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 fi
 
 list_all_versions() {
-  list_github_tags
+  list_github_releases
 }
 
-list_github_tags() {
-  git ls-remote --tags --refs "$GH_REPO" |
-    grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//'
+list_github_releases() {
+  curl "${curl_opts[@]}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/$OWNER/$REPO/releases \
+  | awk -F': ' '/tag_name/{gsub(/[v",]*/, "");print $2}'
 }
 
 sort_versions() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR uses the GitHub API to list releases instead of using `git ls-remote --tags`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The latest tag on https://github.com/aquasecurity/trivy does not have a release so `asdf install trivy latest` results in

```
asdf-trivy: Could not download https://github.com/aquasecurity/trivy/releases/download/v0.57.0/trivy_0.57.0_Linux-64bit.tar.gz | stderr: curl: (22) The requested URL returned error: 404
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

Installing current version

## How Has This Been Tested?

```
11:44 $ asdf plugin test trivy https://github.com/matt-undo/asdf-trivy.git --asdf-plugin-gitref list-by-github-release trivy --version 
Location of trivy plugin: /tmp/asdf.lrhQ/plugins/trivy
Updating trivy to list-by-github-release
From https://github.com/matt-undo/asdf-trivy
 * [new branch]      list-by-github-release -> list-by-github-release
Switched to branch 'list-by-github-release'
* Downloading trivy release 0.56.2...
trivy 0.56.2 installation was successful in /tmp/asdf.lrhQ/installs/trivy/0.56.2/bin!
Version: 0.56.2
Check Bundle:
  Digest: sha256:9cc30e6eb1c0dc0b4a4791b61c3dbff8799d08daeac893c08317e7b054ecab14
  DownloadedAt: 2024-10-31 16:44:38.875128001 +0000 UTC
```
<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
